### PR TITLE
DOC: improve User-Guide of timezone parameter

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -41,7 +41,7 @@ Empty lines and empty values (columns) are always ignored.
 
 #### Preview
 
-* timezone: The timezone will only be added if there is no plus sign in the existing value. Used for both time.source and time.observation.
+* timezone: The timezone will only be added if there is no timezone detected in the existing value. Used for both time.source and time.observation.
 * dry run: sets classification type and identifier to `test`
 
 ##### Custom Input fields


### PR DESCRIPTION
 * Fix description to remove the plus sign test, because since https://github.com/certat/intelmq-webinput-csv/commit/31a848d7c344aa39ed313b4647d7859dd32019ca#diff-c4a8890ac9a558fbb24b52ab5419bb78R322 the plus sign is not used as detector anymore.