### PR TITLE
fix: extensive loading harmonization config

### DIFF
--- a/intelmq_webinput_csv/bin/backend.py
+++ b/intelmq_webinput_csv/bin/backend.py
@@ -18,7 +18,7 @@ from intelmq.bots.experts.taxonomy.expert import TAXONOMY
 from intelmq.lib.message import Event, MessageFactory
 from intelmq.lib.pipeline import PipelineFactory
 from intelmq.lib.exceptions import InvalidValue, KeyExists
-from intelmq.lib.utils import RewindableFileHandle
+from intelmq.lib.utils import RewindableFileHandle, load_configuration
 
 from intelmq_webinput_csv.version import __version__
 
@@ -406,8 +406,7 @@ def submit():
     raw_header = []
 
     # Ensure Harmonization config is only loaded once
-    harmonization_config = dict()
-    harmonization_config['event'] = Event().harmonization_config
+    harmonization = load_configuration(HARMONIZATION_CONF_FILE)
 
     with open(tmp_file[0], encoding='utf8') as handle:
         handle_rewindable = RewindableFileHandle(handle)
@@ -422,7 +421,7 @@ def submit():
         for _ in range(parameters['skipInitialLines']):
             next(reader)
         for lineindex, line in enumerate(reader):
-            event = Event(harmonization=harmonization_config)
+            event = Event(harmonization=harmonization)
             try:
                 for columnindex, (column, value) in \
                         enumerate(zip(parameters['columns'], line)):

--- a/intelmq_webinput_csv/bin/backend.py
+++ b/intelmq_webinput_csv/bin/backend.py
@@ -404,6 +404,11 @@ def submit():
     successful_lines = 0
 
     raw_header = []
+
+    # Ensure Harmonization config is only loaded once
+    harmonization_config = dict()
+    harmonization_config['event'] = Event().harmonization_config
+
     with open(tmp_file[0], encoding='utf8') as handle:
         handle_rewindable = RewindableFileHandle(handle)
         reader = csv.reader(handle_rewindable, delimiter=parameters['delimiter'],
@@ -417,7 +422,7 @@ def submit():
         for _ in range(parameters['skipInitialLines']):
             next(reader)
         for lineindex, line in enumerate(reader):
-            event = Event()
+            event = Event(harmonization=harmonization_config)
             try:
                 for columnindex, (column, value) in \
                         enumerate(zip(parameters['columns'], line)):


### PR DESCRIPTION
When `Event` is init, it automatically loads the harmonization config file. This means that for every event uploaded, the entire harmonization config file is loaded and parsed. This dramatically extends the time needed to parse a single event.

This PR ensures that the harmonization file is only loaded once and then used for generating all `Event` objects.

Fixes: #79