### PR TITLE
docs: remove broken link in toc to native package installation

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,7 +2,6 @@
 
 1. [Requirements](#requirements)
 2. [Installation](#installation)
-   * [Native packages](#native-packages)
    * [With pip](#with-pip)
      * [From PyPi](#from-pypi)
      * [From the repository](#from-the-repository)


### PR DESCRIPTION
the link in the toc does not link to any content
and this software is not packaged (at least not this variant), so there's no native package installation at all